### PR TITLE
fix: pass model, max_turns, allowed_tools via claude_args and settings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,9 +77,8 @@ runs:
       with:
         prompt_file: ${{ steps.prepare.outputs.prompt_file }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
-        model: ${{ steps.prepare.outputs.model }}
-        max_turns: ${{ steps.prepare.outputs.max_turns }}
-        allowed_tools: ${{ steps.prepare.outputs.allowed_tools }}
+        claude_args: ${{ steps.prepare.outputs.claude_args }}
+        settings: ${{ steps.prepare.outputs.settings_file }}
 
     - name: Post completion comment
       if: inputs.mode == 'execute' && !failure()

--- a/dist/index.js
+++ b/dist/index.js
@@ -34325,11 +34325,18 @@ async function run() {
         const tmpDir = os.tmpdir();
         const promptFile = path.join(tmpDir, `leonidas-prompt-${Date.now()}.md`);
         fs.writeFileSync(promptFile, prompt, "utf-8");
+        // Write settings file with allowed tools permissions
+        const settingsFile = path.join(tmpDir, `leonidas-settings-${Date.now()}.json`);
+        const settings = {
+            permissions: {
+                allow: allowedTools.split(",").map((t) => t.trim()),
+            },
+        };
+        fs.writeFileSync(settingsFile, JSON.stringify(settings), "utf-8");
         // Set outputs for composite action
         core.setOutput("prompt_file", promptFile);
-        core.setOutput("model", config.model);
-        core.setOutput("max_turns", maxTurns.toString());
-        core.setOutput("allowed_tools", allowedTools);
+        core.setOutput("claude_args", `--model ${config.model} --max-turns ${maxTurns}`);
+        core.setOutput("settings_file", settingsFile);
     }
     catch (error) {
         if (error instanceof Error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,11 +118,19 @@ async function run(): Promise<void> {
     const promptFile = path.join(tmpDir, `leonidas-prompt-${Date.now()}.md`);
     fs.writeFileSync(promptFile, prompt, "utf-8");
 
+    // Write settings file with allowed tools permissions
+    const settingsFile = path.join(tmpDir, `leonidas-settings-${Date.now()}.json`);
+    const settings = {
+      permissions: {
+        allow: allowedTools.split(",").map((t) => t.trim()),
+      },
+    };
+    fs.writeFileSync(settingsFile, JSON.stringify(settings), "utf-8");
+
     // Set outputs for composite action
     core.setOutput("prompt_file", promptFile);
-    core.setOutput("model", config.model);
-    core.setOutput("max_turns", maxTurns.toString());
-    core.setOutput("allowed_tools", allowedTools);
+    core.setOutput("claude_args", `--model ${config.model} --max-turns ${maxTurns}`);
+    core.setOutput("settings_file", settingsFile);
   } catch (error) {
     if (error instanceof Error) {
       core.setFailed(error.message);


### PR DESCRIPTION
## Summary

- Fix `base-action` integration by passing `model` and `max_turns` via `claude_args` (`--model`, `--max-turns`) and `allowed_tools` via `settings` JSON file (`permissions.allow`)
- The `base-action` does not accept `model`, `max_turns`, or `allowed_tools` as direct inputs, causing them to be silently ignored
- This resulted in Claude Code being unable to post plan comments due to permission denials on `gh issue comment`

## Test plan

- [ ] Trigger plan workflow by creating/labeling an issue with `leonidas` label
- [ ] Verify Claude Code receives correct model, max_turns, and allowed_tools
- [ ] Verify plan comment is successfully posted to the issue
- [ ] Trigger execute workflow by commenting `/approve` on the issue
- [ ] Verify PR is created successfully

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)