### PR TITLE
fix: resolve setup-node cache path error in composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -64,8 +64,6 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: 20
-        cache: npm
-        cache-dependency-path: ${{ github.action_path }}/package-lock.json
 
     - name: Install action dependencies
       shell: bash
@@ -105,6 +103,7 @@ runs:
         prompt_file: ${{ steps.prepare.outputs.prompt_file }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
         show_full_output: "true"
+        use_node_cache: "false"
 
     - name: Post completion comment
       if: inputs.mode == 'execute' && !failure()


### PR DESCRIPTION
## Summary

- Remove npm cache from `action.yml`'s composite action Setup Node.js step — `github.action_path` resolves to `./` for local actions (`uses: ./`), causing `actions/glob` to reject `.//package-lock.json` path (setup-node v4.4.0+ security hardening)
- Add `use_node_cache: "false"` to `claude-code-action/base-action` step to explicitly disable caching, preventing CI workflow input leakage
- Add explicit `cache-dependency-path: package-lock.json` to `ci.yml` as defensive measure

## Root Cause

When `actions/setup-node@v4` runs inside a composite action with `uses: ./`, `github.action_path` resolves to `./`. The `cache-dependency-path` then becomes `.//package-lock.json`, which `@actions/glob` v4.4.0+ rejects due to patterns containing `.` being blocked for security reasons.

Additionally, there was an intermittent GitHub Actions platform issue where CI workflow's `setup-node` parameters (including `cache: npm`) leaked into the composite action's execution context.

## Test Plan

- [ ] CI workflow passes (typecheck + build)
- [ ] Manual test: create issue with `leonidas` label → plan workflow succeeds
- [ ] Manual test: `/approve` comment → execute workflow succeeds without setup-node cache errors

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)