### PR TITLE
Fix TypeScript compilation errors in CI

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { LeonidasConfig, ActionInputs } from "./types";
+import { resolveLanguage } from "./i18n";
 
 const DEFAULT_CONFIG: LeonidasConfig = {
   label: "leonidas",
@@ -55,7 +56,7 @@ export function mergeConfig(
     merged.base_branch = inputs.base_branch;
   }
   if (inputs.language) {
-    merged.language = inputs.language;
+    merged.language = resolveLanguage(inputs.language);
   }
 
   // Validate label format: alphanumeric, hyphens, underscores only

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -960,7 +960,7 @@ describe("main", () => {
       const { parseSubIssueMetadata } = await import("./github");
       vi.mocked(parseSubIssueMetadata).mockReturnValue({
         parent_issue_number: 100,
-        order: "1/3",
+        order: 1,
         total: 3,
       });
 
@@ -975,7 +975,7 @@ describe("main", () => {
         "system prompt",
         {
           parent_issue_number: 100,
-          order: "1/3",
+          order: 1,
           total: 3,
         },
         "zh",

--- a/src/prompts/plan.test.ts
+++ b/src/prompts/plan.test.ts
@@ -23,8 +23,8 @@ describe("prompts/plan", () => {
       expect(result).toContain("## Scope Constraints");
       expect(result).toContain("**Maximum 7 implementation steps.**");
       expect(result).toContain("## Instructions");
-      expect(result).toContain(PLAN_HEADER);
-      expect(result).toContain(PLAN_FOOTER);
+      expect(result).toContain(getPlanHeader());
+      expect(result).toContain(getPlanFooter());
       expect(result).toContain(`gh issue comment ${issueNumber} --body "<plan>"`);
     });
 

--- a/src/prompts/plan.ts
+++ b/src/prompts/plan.ts
@@ -79,7 +79,7 @@ Part of #${issueNumber}: ${issueTitle}
 
 The comment MUST start with this exact header and include the decomposed marker:
 
-${PLAN_HEADER}
+${planHeader}
 
 ${DECOMPOSED_MARKER}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type LeonidasMode = "plan" | "execute";
 
+import { SupportedLanguage } from "./i18n";
+
 export interface LeonidasConfig {
   label: string;
   model: string;
@@ -7,7 +9,7 @@ export interface LeonidasConfig {
   base_branch: string;
   allowed_tools: string[];
   max_turns: number;
-  language: string;
+  language: SupportedLanguage;
 }
 
 export interface ActionInputs {


### PR DESCRIPTION
## Summary
- Strengthen `LeonidasConfig.language` type from `string` to `SupportedLanguage` to resolve 5 type mismatch errors in main.ts
- Use `resolveLanguage()` in config merge for type-safe language assignment from user input
- Fix stale `PLAN_HEADER` reference in plan.ts decomposed plan template
- Update plan.test.ts to use `getPlanHeader()`/`getPlanFooter()` function calls
- Fix test mock: `SubIssueMetadata.order` from string `"1/3"` to number `1`

Closes #56

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [x] All 157 tests pass (`vitest run`)
- [x] `ncc build` succeeds without errors
- [ ] CI build passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)