### PR TITLE
fix: align test expectations with rules_path implementation

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -81,6 +81,7 @@ describe("config", () => {
       ],
       max_turns: 50,
       language: "en",
+      rules_path: ".github/leonidas-rules",
     };
 
     it("should merge file config with default config", () => {

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -281,12 +281,8 @@ Malformed numbers`;
 
       const result = parseSubIssueMetadata(issueBody);
 
-      // Should still parse but with NaN values converted to numbers
-      expect(result).toEqual({
-        parent_issue_number: NaN,
-        order: NaN,
-        total: NaN,
-      });
+      // Regex requires \d+ so non-numeric values won't match
+      expect(result).toBeUndefined();
     });
 
     it("should use first match when multiple parent comments exist", () => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -772,6 +772,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "ko",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -782,7 +783,7 @@ describe("main", () => {
 
       await import("./main");
 
-      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "ko");
+      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "ko", undefined);
       expect(buildPlanPrompt).toHaveBeenCalledWith(
         "Test Issue",
         "Test body",
@@ -828,6 +829,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "es",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -842,7 +844,7 @@ describe("main", () => {
 
       await import("./main");
 
-      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "es");
+      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "es", undefined);
       expect(buildExecutePrompt).toHaveBeenCalledWith(
         "Test Issue",
         "Test body",
@@ -893,6 +895,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -903,7 +906,7 @@ describe("main", () => {
 
       await import("./main");
 
-      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "en");
+      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "en", undefined);
       expect(buildPlanPrompt).toHaveBeenCalledWith(
         "Test Issue",
         "Test body",
@@ -949,6 +952,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "zh",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -966,7 +970,7 @@ describe("main", () => {
 
       await import("./main");
 
-      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "zh");
+      expect(buildSystemPrompt).toHaveBeenCalledWith(".github/leonidas.md", "zh", undefined);
       expect(buildSubIssuePlanPrompt).toHaveBeenCalledWith(
         "[1/3] Test Sub-Issue",
         "<!-- leonidas-parent: #100 -->\n<!-- leonidas-order: 1/3 -->\nTest sub-issue body",


### PR DESCRIPTION
## Summary
- Fix `parseSubIssueMetadata` malformed HTML test: regex uses `\d+` so non-numeric values (`#abc`, `x/y`) correctly return `undefined`, not a NaN object
- Add missing `rules_path` field to `defaultConfig` in `config.test.ts`
- Add 3rd argument (`rules`) to `buildSystemPrompt` assertions in `main.test.ts`
- Add `rules_path` to `resolveConfig` mocks in language parameter wiring tests

Fixes 7 test failures (1 original + 6 from rules_path feature commits).

Closes #93

## Test plan
- [x] All 224 tests pass locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)