### PR TITLE
fix: add missing rules_path to test config objects

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -100,6 +100,7 @@ describe("config", () => {
         ...defaultConfig,
         model: "claude-opus-4",
         max_turns: 100,
+        rules_path: ".github/leonidas-rules",
       });
     });
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -69,6 +69,7 @@ describe("main", () => {
         allowed_tools: ["Read", "Write"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -123,6 +124,7 @@ describe("main", () => {
         allowed_tools: ["Read", "Write", "Edit"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -202,6 +204,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -253,6 +256,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -304,6 +308,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -390,6 +395,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -446,6 +452,7 @@ describe("main", () => {
         allowed_tools: ["Read", "Write"],
         max_turns: 100,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -524,6 +531,7 @@ describe("main", () => {
         allowed_tools: ["Read", "Write", "Edit", "Bash(git:*)"],
         max_turns: 60,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -581,6 +589,7 @@ describe("main", () => {
         allowed_tools: ["Read", "Write", "Edit", "Bash(npm:*)", "Bash(git:*)"],
         max_turns: 75,
         language: "ja",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -654,6 +663,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");
@@ -724,6 +734,7 @@ describe("main", () => {
         allowed_tools: ["Read"],
         max_turns: 50,
         language: "en",
+        rules_path: ".github/leonidas-rules",
       });
 
       const { buildSystemPrompt } = await import("./prompts/system");


### PR DESCRIPTION
## Summary

- Add missing `rules_path` property to all `LeonidasConfig` mock objects in test files
- Fixes 12 TypeScript `TS2345` errors causing `npm run typecheck` to fail

Closes #94

## Changes

| File | Fix |
|------|-----|
| `src/main.test.ts` | Added `rules_path: ".github/leonidas-rules"` to 11 config objects |
| `src/config.test.ts` | Added `rules_path: ".github/leonidas-rules"` to 1 config object |

## Test plan

- [x] `npm run typecheck` passes (0 errors)
- [x] `npm test` passes (224/224 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)