### PR TITLE
fix: remove workflows:write permission that breaks workflow triggers

### DIFF
--- a/.github/workflows/leonidas-execute.yml
+++ b/.github/workflows/leonidas-execute.yml
@@ -16,7 +16,6 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
-      workflows: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Remove `workflows: write` permission from `leonidas-execute.yml` that was added in PR #131
- This permission causes GitHub Actions to treat the workflow file as invalid, preventing all `issue_comment` triggers from firing
- After PR #131 was merged, every `/approve` comment failed to trigger the execute workflow

## Root Cause
The `workflows: write` permission (allows modifying workflow files) is a security-sensitive permission that causes workflow file validation failures. Since leonidas never modifies `.github/workflows/` files, this permission is unnecessary.

## Test plan
- [ ] After merge, push to main should NOT show "workflow file issue" error for leonidas-execute
- [ ] `/approve` comment on issue #53 should trigger the execute workflow

Closes #53 (unblocks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)