### PR TITLE
Fix CI triggers to run on feature branches only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches-ignore:
+      - main
   pull_request:
-    branches: [main]
-  workflow_dispatch:
+    branches-ignore:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Update CI workflow triggers to use `branches-ignore: main` instead of `branches: [main]`
- CI now runs on pushes to feature branches and PRs targeting non-main branches
- Remove `workflow_dispatch` trigger (no longer needed)

Closes #151

## Test plan
- [ ] Verify CI runs on this PR's feature branch push
- [ ] Verify CI does not trigger on direct main pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)