### PR TITLE
chore: add missing entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,14 @@ CLAUDE.md
 
 # Planning artifacts
 plan.md
+
+# Test coverage
+coverage/
+
+# AI tools local state
+.codingbuddy/
+docs/codingbuddy/
+.omc/
+
+# TypeScript build cache
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- Add `coverage/` for test coverage report output
- Add `.codingbuddy/`, `docs/codingbuddy/`, `.omc/` for AI development tool local state
- Add `*.tsbuildinfo` for TypeScript incremental build cache

These were showing up as untracked files in `git status` and should not be committed.

## Test plan
- [x] Verify `git status` no longer shows untracked directories
- [x] Confirm no tracked files were accidentally ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)