### PR TITLE
fix: clean up temp prompt file after use

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,11 @@ runs:
         show_full_output: "true"
         use_node_cache: "false"
 
+    - name: Cleanup prompt file
+      if: always()
+      shell: bash
+      run: rm -f "${{ steps.prepare.outputs.prompt_file }}"
+
     - name: Link native sub-issues (if decomposed)
       if: inputs.mode == 'plan' && !failure()
       shell: bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -211,7 +211,8 @@ async function run(): Promise<void> {
     }
 
     // Write prompt to temp file to avoid shell escaping issues
-    const tmpDir = os.tmpdir();
+    // Prefer RUNNER_TEMP (cleaned per-job by GitHub Actions) over os.tmpdir()
+    const tmpDir = process.env.RUNNER_TEMP || os.tmpdir();
     const promptFile = path.join(tmpDir, `leonidas-prompt-${Date.now()}.md`);
     fs.writeFileSync(promptFile, prompt, "utf-8");
 


### PR DESCRIPTION
## Summary
- Use `RUNNER_TEMP` (cleaned per-job by GitHub Actions) instead of `os.tmpdir()` for temp prompt files, with `os.tmpdir()` as fallback for non-Actions environments
- Add unconditional cleanup step in `action.yml` to remove the prompt file after `claude-code-action` completes
- Add test coverage for `RUNNER_TEMP` usage

## Test plan
- [x] New test verifies `RUNNER_TEMP` is used when available
- [x] Existing tests still pass (296 total)
- [x] TypeScript type check passes
- [ ] CI pipeline passes

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)