### PR TITLE
ci: add path-based triggers to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,28 @@ on:
   push:
     branches-ignore:
       - main
+    paths:
+      - "src/**"
+      - "action.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "eslint.config.mjs"
+      - ".github/workflows/ci.yml"
+      - ".github/actions/**"
   pull_request:
     branches-ignore:
       - main
+    paths:
+      - "src/**"
+      - "action.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "tsconfig.json"
+      - "eslint.config.mjs"
+      - ".github/workflows/ci.yml"
+      - ".github/actions/**"
+  workflow_dispatch:
 
 jobs:
   install:


### PR DESCRIPTION
## Summary
- Add path filters to `push` and `pull_request` triggers in CI workflow
- CI only runs when relevant source/config files change
- Documentation-only changes (README, LICENSE, etc.) no longer trigger CI
- Add `workflow_dispatch` for manual trigger escape hatch

## Paths included

| Path | Reason |
|------|--------|
| `src/**` | Source code + co-located tests |
| `action.yml` | Action definition |
| `package.json` | Dependencies, scripts |
| `package-lock.json` | Locked dependency versions |
| `tsconfig.json` | TypeScript config |
| `eslint.config.mjs` | Lint config |
| `.github/workflows/ci.yml` | CI workflow itself |
| `.github/actions/**` | Composite actions |

## Paths excluded (by omission)

| Path | Reason |
|------|--------|
| `README.md` | Documentation only |
| `CONTRIBUTING.md` | Documentation only |
| `LICENSE` | No code impact |
| `docs/**` | Documentation only |
| `.github/workflows/leonidas-*.yml` | Separate workflows |
| `.github/workflows/renovate-*.yml` | Separate workflow |

## Test plan
- [ ] CI triggers on this PR (modifies `.github/workflows/ci.yml`, which is in the paths list)
- [ ] README-only changes should NOT trigger CI
- [ ] `workflow_dispatch` available for manual runs

Closes #109

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>