### PR TITLE
fix: replace grep -oP with portable grep -oE in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,8 @@ runs:
         echo "Decomposed plan found. Linking sub-issues to parent #$ISSUE_NUMBER..."
 
         # Extract sub-issue numbers from checklist (e.g., "- [ ] #36 — ...")
-        SUB_ISSUES=$(echo "$COMMENT_BODY" | grep -oP '- \[[ x]\] #\K\d+' || true)
+        # Use grep -oE (ERE) instead of grep -oP (PCRE) for portability across non-GNU environments
+        SUB_ISSUES=$(echo "$COMMENT_BODY" | grep -oE '- \[[ x]\] #[0-9]+' | grep -oE '[0-9]+$' || true)
 
         if [ -z "$SUB_ISSUES" ]; then
           echo "No sub-issue numbers found in checklist."


### PR DESCRIPTION
## Summary
- Replace GNU-only `grep -oP` (PCRE) with POSIX-compatible `grep -oE` (ERE) for sub-issue number extraction
- Ensures portability across non-GNU environments (macOS, Alpine Linux)
- Two-stage `grep -oE` pipeline produces identical output to original `grep -oP` with `\K`

## Changes
- `action.yml:142` — Replace `grep -oP '- \[[ x]\] #\K\d+'` with `grep -oE '- \[[ x]\] #[0-9]+' | grep -oE '[0-9]+$'`

## Test plan
- [ ] CI passes (lint, typecheck, test, build)
- [ ] Verify grep pattern extracts correct sub-issue numbers from checklist format
- [ ] Functional test: create an issue with sub-issues and verify linking works

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)