### PR TITLE
feat(i18n): apply i18n to hardcoded starting_implementation string

### DIFF
--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -266,4 +266,18 @@ describe("post-processing translation keys", () => {
     const result = t("failure_execute_body", "en", "https://example.com/run");
     expect(result).toContain("https://example.com/run");
   });
+
+  it("should have starting_implementation translation for all languages", () => {
+    for (const lang of languages) {
+      const result = t("starting_implementation", lang, 42);
+      expect(result).not.toBe("[Missing translation: starting_implementation]");
+      expect(result).toContain("42");
+    }
+  });
+
+  it("should interpolate starting_implementation correctly", () => {
+    const result = t("starting_implementation", "en", 99);
+    expect(result).toContain("#99");
+    expect(result).toContain("Leonidas");
+  });
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,7 +61,8 @@ export type TranslationKey =
   | "partial_pr_body"
   | "failure_header"
   | "failure_plan_body"
-  | "failure_execute_body";
+  | "failure_execute_body"
+  | "starting_implementation";
 
 /**
  * Translation map containing all localized strings for supported languages
@@ -90,6 +91,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "The automated plan encountered an error.\n\n**Workflow run:** [View logs](%s)\n\n**To retry:** Remove the `leonidas` label and re-add it.",
     failure_execute_body:
       "The automated execution encountered an error.\n\n**Workflow run:** [View logs](%s)\n\n**To retry:** Comment `/approve` again on this issue.",
+    starting_implementation: "⚡ **Leonidas** is starting implementation for issue #%d...",
   },
   ko: {
     plan_header: "## 🏛️ 레오니다스 구현 계획",
@@ -114,6 +116,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "자동화된 계획이 오류를 발생시켰습니다.\n\n**워크플로 실행:** [로그 보기](%s)\n\n**재시도하려면:** `leonidas` 레이블을 제거한 후 다시 추가하세요.",
     failure_execute_body:
       "자동화된 실행이 오류를 발생시켰습니다.\n\n**워크플로 실행:** [로그 보기](%s)\n\n**재시도하려면:** 이 이슈에 `/approve`를 다시 댓글로 다세요.",
+    starting_implementation: "⚡ **레오니다스**가 이슈 #%d에 대한 구현을 시작합니다...",
   },
   ja: {
     plan_header: "## 🏛️ レオニダス実装計画",
@@ -138,6 +141,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "自動計画でエラーが発生しました。\n\n**ワークフロー実行:** [ログを表示](%s)\n\n**再試行するには:** `leonidas` ラベルを削除してから再度追加してください。",
     failure_execute_body:
       "自動実行でエラーが発生しました。\n\n**ワークフロー実行:** [ログを表示](%s)\n\n**再試行するには:** このイシューに `/approve` を再度コメントしてください。",
+    starting_implementation: "⚡ **Leonidas**がイシュー #%d の実装を開始しています...",
   },
   zh: {
     plan_header: "## 🏛️ 列奥尼达实施计划",
@@ -160,6 +164,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "自动计划遇到错误。\n\n**工作流运行:** [查看日志](%s)\n\n**重试:** 移除 `leonidas` 标签，然后重新添加。",
     failure_execute_body:
       "自动执行遇到错误。\n\n**工作流运行:** [查看日志](%s)\n\n**重试:** 在此问题上再次评论 `/approve`。",
+    starting_implementation: "⚡ **Leonidas** 正在开始实现问题 #%d...",
   },
   es: {
     plan_header: "## 🏛️ Plan de Implementación de Leonidas",
@@ -184,6 +189,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "El plan automatizado encontró un error.\n\n**Ejecución del workflow:** [Ver logs](%s)\n\n**Para reintentar:** Elimina la etiqueta `leonidas` y agrégala nuevamente.",
     failure_execute_body:
       "La ejecución automatizada encontró un error.\n\n**Ejecución del workflow:** [Ver logs](%s)\n\n**Para reintentar:** Comenta `/approve` nuevamente en este issue.",
+    starting_implementation: "⚡ **Leonidas** está comenzando la implementación del issue #%d...",
   },
   de: {
     plan_header: "## 🏛️ Leonidas Implementierungsplan",
@@ -208,6 +214,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "Der automatisierte Plan ist auf einen Fehler gestoßen.\n\n**Workflow-Ausführung:** [Logs anzeigen](%s)\n\n**Zum Wiederholen:** Entfernen Sie das `leonidas` Label und fügen Sie es erneut hinzu.",
     failure_execute_body:
       "Die automatisierte Ausführung ist auf einen Fehler gestoßen.\n\n**Workflow-Ausführung:** [Logs anzeigen](%s)\n\n**Zum Wiederholen:** Kommentieren Sie erneut `/approve` in diesem Issue.",
+    starting_implementation: "⚡ **Leonidas** beginnt mit der Implementierung von Issue #%d...",
   },
   fr: {
     plan_header: "## 🏛️ Plan d'Implémentation Leonidas",
@@ -232,6 +239,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "Le plan automatisé a rencontré une erreur.\n\n**Exécution du workflow :** [Voir les logs](%s)\n\n**Pour réessayer :** Retirez le label `leonidas` puis rajoutez-le.",
     failure_execute_body:
       "L'exécution automatisée a rencontré une erreur.\n\n**Exécution du workflow :** [Voir les logs](%s)\n\n**Pour réessayer :** Commentez à nouveau `/approve` sur ce ticket.",
+    starting_implementation: "⚡ **Leonidas** commence l'implémentation du ticket #%d...",
   },
   pt: {
     plan_header: "## 🏛️ Plano de Implementação Leonidas",
@@ -256,6 +264,7 @@ const translations: Record<SupportedLanguage, Record<TranslationKey, string>> = 
       "O plano automatizado encontrou um erro.\n\n**Execução do workflow:** [Ver logs](%s)\n\n**Para tentar novamente:** Remova o label `leonidas` e adicione-o novamente.",
     failure_execute_body:
       "A execução automatizada encontrou um erro.\n\n**Execução do workflow:** [Ver logs](%s)\n\n**Para tentar novamente:** Comente `/approve` novamente neste issue.",
+    starting_implementation: "⚡ **Leonidas** está iniciando a implementação do issue #%d...",
   },
 };
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -237,7 +237,7 @@ describe("main", () => {
       expect(mockClient.findPlanComment).toHaveBeenCalledWith(5);
       expect(mockClient.postComment).toHaveBeenCalledWith(
         5,
-        "⚡ **Leonidas** is starting implementation for issue #5...",
+        expect.stringContaining("starting implementation"),
       );
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { buildPlanPrompt, buildSubIssuePlanPrompt } from "./prompts/plan";
 import { buildExecutePrompt } from "./prompts/execute";
 import { createGitHubClient, parseSubIssueMetadata, isDecomposedPlan } from "./github";
 import type { GitHubClient } from "./github";
+import { t } from "./i18n";
 
 export function readInputs(): ActionInputs {
   const modeRaw = core.getInput("mode", { required: true });
@@ -193,7 +194,7 @@ export async function handleExecuteMode(
 
   await client.postComment(
     context.issue_number,
-    `⚡ **Leonidas** is starting implementation for issue #${context.issue_number}...`,
+    t("starting_implementation", config.language, context.issue_number),
   );
 
   const prompt = buildExecutePrompt({


### PR DESCRIPTION
## Summary

- `TranslationKey` 타입에 `starting_implementation` 키 추가
- 8개 언어(en, ko, ja, zh, es, de, fr, pt) 번역 문자열 등록
- `main.ts`의 하드코딩된 영어 문자열을 `t("starting_implementation", config.language, context.issue_number)`로 교체
- 관련 테스트 2건 추가 및 기존 테스트 호환성 유지

## Test plan

- [x] `npm test` - 398개 테스트 전부 통과
- [x] `npm run typecheck` - 타입 체크 통과
- [x] `npm run lint` - 린트 통과
- [x] `npm run build` - 빌드 성공

Closes #225